### PR TITLE
Support LDO claims via configuration

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -7,6 +7,7 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
+    "lint:fix": "vue-cli-service lint --fix",
     "start": "vue-cli-service express:run"
   },
   "dependencies": {

--- a/client/src/config/homestead-lido.json
+++ b/client/src/config/homestead-lido.json
@@ -3,7 +3,7 @@
   "chainId": 1,
   "rpcUrl": "https://mainnet.infura.io/v3/7a887133ccb042cf8547e30a53f57169",
   "addresses": {
-    "merkleRedeem": "0x6bd0B17713aaa29A2d7c9A39dDc120114f9fD809",
+    "merkleRedeem": "0x884226c9f7b7205f607922E0431419276a64CF8f",
     "multicall": "0xeefBa1e63905eF1D7ACbA5a8513c70307C1cE441"
   },
   "rewardToken": "LDO",

--- a/client/src/config/homestead-lido.json
+++ b/client/src/config/homestead-lido.json
@@ -7,6 +7,8 @@
     "multicall": "0xeefBa1e63905eF1D7ACbA5a8513c70307C1cE441"
   },
   "rewardToken": "LDO",
+  "snapshotUrl": "https://raw.githubusercontent.com/balancer-labs/bal-mining-scripts/master/reports/_current-lido.json",
+  "reportsUrl": "https://github.com/balancer-labs/bal-mining-scripts/blob/master/reports-ldo",
   "connectors": {
     "injected": {
       "id": "injected",

--- a/client/src/config/homestead-lido.json
+++ b/client/src/config/homestead-lido.json
@@ -1,12 +1,12 @@
 {
-  "network": "kovan",
-  "chainId": 42,
-  "rpcUrl": "https://kovan.infura.io/v3/7a887133ccb042cf8547e30a53f57169",
+  "network": "homestead-lido",
+  "chainId": 1,
+  "rpcUrl": "https://mainnet.infura.io/v3/7a887133ccb042cf8547e30a53f57169",
   "addresses": {
-    "merkleRedeem": "0x3bc73D276EEE8cA9424Ecb922375A0357c1833B3",
-    "multicall": "0x2cc8688C5f75E365aaEEb4ea8D6a480405A48D2A"
+    "merkleRedeem": "0x6bd0B17713aaa29A2d7c9A39dDc120114f9fD809",
+    "multicall": "0xeefBa1e63905eF1D7ACbA5a8513c70307C1cE441"
   },
-  "rewardToken": "BAL",
+  "rewardToken": "LDO",
   "connectors": {
     "injected": {
       "id": "injected",
@@ -23,7 +23,7 @@
       "id": "portis",
       "name": "Portis",
       "options": {
-        "network": "kovan",
+        "network": "mainnet",
         "dappId": "3f1c3cfc-7dd5-4e8a-aa03-71ff7396d9fe"
       }
     },
@@ -31,10 +31,10 @@
       "id": "walletlink",
       "name": "Coinbase",
       "options": {
-        "appName": "Pool management - Balancer",
+        "appName": "Balancer claim",
         "darkMode": true,
-        "chainId": 42,
-        "ethJsonrpcUrl": "https://eth-kovan.alchemyapi.io/v2/C467LJc7Aa761LLxlcxXvhIG9HzDTtKw"
+        "chainId": 1,
+        "ethJsonrpcUrl": "https://cloudflare-eth.com"
       }
     }
   }

--- a/client/src/config/homestead.json
+++ b/client/src/config/homestead.json
@@ -7,6 +7,8 @@
     "multicall": "0xeefBa1e63905eF1D7ACbA5a8513c70307C1cE441"
   },
   "rewardToken": "BAL",
+  "snapshotUrl": "https://raw.githubusercontent.com/balancer-labs/bal-mining-scripts/master/reports/_current.json",
+  "reportsUrl": "https://github.com/balancer-labs/bal-mining-scripts/blob/master/reports",
   "connectors": {
     "injected": {
       "id": "injected",

--- a/client/src/config/homestead.json
+++ b/client/src/config/homestead.json
@@ -6,6 +6,7 @@
     "merkleRedeem": "0x6d19b2bF3A36A61530909Ae65445a906D98A2Fa8",
     "multicall": "0xeefBa1e63905eF1D7ACbA5a8513c70307C1cE441"
   },
+  "rewardToken": "BAL",
   "connectors": {
     "injected": {
       "id": "injected",

--- a/client/src/config/index.ts
+++ b/client/src/config/index.ts
@@ -1,8 +1,9 @@
 import homestead from '@/config/homestead.json';
+import homesteadLido from '@/config/homestead-lido.json';
 import kovan from '@/config/kovan.json';
 
 const configs = {
-  production: { homestead, kovan }
+  production: { homestead, kovan, homesteadLido }
 };
 const env = process.env.VUE_APP_ENV || 'production';
 const network = process.env.VUE_APP_NETWORK || 'homestead';

--- a/client/src/config/kovan.json
+++ b/client/src/config/kovan.json
@@ -7,6 +7,8 @@
     "multicall": "0x2cc8688C5f75E365aaEEb4ea8D6a480405A48D2A"
   },
   "rewardToken": "BAL",
+  "reportsUrl": "https://github.com/balancer-labs/bal-mining-scripts/blob/master/reports-kovan",
+  "snapshotUrl": "https://raw.githubusercontent.com/balancer-labs/bal-mining-scripts/master/reports-kovan/_current.json",
   "connectors": {
     "injected": {
       "id": "injected",

--- a/client/src/helpers/merkle.ts
+++ b/client/src/helpers/merkle.ts
@@ -4,10 +4,13 @@ import { hexToBytes, toWei, soliditySha3 } from 'web3-utils';
 
 // Merkle tree called with 32 byte hex values
 export class MerkleTree {
-  constructor(elements) {
+  elements: Buffer[];
+  layers: any[];
+
+  constructor(elements: string[]) {
     this.elements = elements
-      .filter(el => el)
-      .map(el => Buffer.from(hexToBytes(el)));
+      .filter((el) => el)
+      .map((el) => Buffer.from(hexToBytes(el)));
 
     // Sort elements
     this.elements.sort(Buffer.compare);
@@ -18,12 +21,12 @@ export class MerkleTree {
     this.layers = this.getLayers(this.elements);
   }
 
-  getLayers(elements) {
+  getLayers(elements: Buffer[]) {
     if (elements.length === 0) {
       return [['']];
     }
 
-    const layers = [];
+    const layers: any[][] = [];
     layers.push(elements);
 
     // Get next layer until we reach the root
@@ -34,8 +37,8 @@ export class MerkleTree {
     return layers;
   }
 
-  getNextLayer(elements) {
-    return elements.reduce((layer, el, idx, arr) => {
+  getNextLayer(elements: Buffer[]) {
+    return elements.reduce((layer: any, el: any, idx: number, arr: any[]) => {
       if (idx % 2 === 0) {
         // Hash the current element with its pair element
         layer.push(this.combinedHash(el, arr[idx + 1]));
@@ -45,7 +48,7 @@ export class MerkleTree {
     }, []);
   }
 
-  combinedHash(first, second) {
+  combinedHash(first: string, second: string): Buffer | string {
     if (!first) {
       return second;
     }
@@ -64,7 +67,7 @@ export class MerkleTree {
     return bufferToHex(this.getRoot());
   }
 
-  getProof(el) {
+  getProof(el: Buffer) {
     let idx = this.bufIndexOf(el, this.elements);
 
     if (idx === -1) {
@@ -85,7 +88,7 @@ export class MerkleTree {
   }
 
   // external call - convert to buffer
-  getHexProof(_el) {
+  getHexProof(_el: any) {
     const el = Buffer.from(hexToBytes(_el));
 
     const proof = this.getProof(el);
@@ -93,7 +96,7 @@ export class MerkleTree {
     return this.bufArrToHexArr(proof);
   }
 
-  getPairElement(idx, layer) {
+  getPairElement(idx: number, layer: any) {
     const pairIdx = idx % 2 === 0 ? idx + 1 : idx - 1;
 
     if (pairIdx < layer.length) {
@@ -103,14 +106,14 @@ export class MerkleTree {
     }
   }
 
-  bufIndexOf(el, arr) {
+  bufIndexOf(el: Buffer | string, arr: Buffer[]) {
     let hash;
 
     // Convert element to 32 byte hash if it is not one already
     if (el.length !== 32 || !Buffer.isBuffer(el)) {
-      hash = keccakFromString(el);
+      hash = keccakFromString(el as string);
     } else {
-      hash = el;
+      hash = el as Buffer;
     }
 
     for (let i = 0; i < arr.length; i++) {
@@ -122,31 +125,29 @@ export class MerkleTree {
     return -1;
   }
 
-  bufDedup(elements) {
-    return elements.filter((el, idx) => {
+  bufDedup(elements: Buffer[]) {
+    return elements.filter((el, idx: number) => {
       return idx === 0 || !elements[idx - 1].equals(el);
     });
   }
 
-  bufArrToHexArr(arr) {
-    if (arr.some(el => !Buffer.isBuffer(el))) {
+  bufArrToHexArr(arr: Buffer[]) {
+    if (arr.some((el) => !Buffer.isBuffer(el))) {
       throw new Error('Array is not an array of buffers');
     }
 
-    return arr.map(el => '0x' + el.toString('hex'));
+    return arr.map((el: Buffer) => '0x' + el.toString('hex'));
   }
 
-  sortAndConcat(...args) {
+  sortAndConcat(...args: any[]) {
     return Buffer.concat([...args].sort(Buffer.compare));
   }
 }
 
 export function loadTree(balances) {
-  const elements = [];
-  Object.keys(balances).forEach(address => {
+  const elements = Object.keys(balances).map((address) => {
     const balance = toWei(balances[address]);
-    const leaf = soliditySha3(address, balance);
-    elements.push(leaf);
+    return soliditySha3(address, balance) as string;
   });
   return new MerkleTree(elements);
 }

--- a/client/src/helpers/merkle.ts
+++ b/client/src/helpers/merkle.ts
@@ -9,8 +9,8 @@ export class MerkleTree {
 
   constructor(elements: string[]) {
     this.elements = elements
-      .filter((el) => el)
-      .map((el) => Buffer.from(hexToBytes(el)));
+      .filter(el => el)
+      .map(el => Buffer.from(hexToBytes(el)));
 
     // Sort elements
     this.elements.sort(Buffer.compare);
@@ -132,7 +132,7 @@ export class MerkleTree {
   }
 
   bufArrToHexArr(arr: Buffer[]) {
-    if (arr.some((el) => !Buffer.isBuffer(el))) {
+    if (arr.some(el => !Buffer.isBuffer(el))) {
       throw new Error('Array is not an array of buffers');
     }
 
@@ -145,7 +145,7 @@ export class MerkleTree {
 }
 
 export function loadTree(balances) {
-  const elements = Object.keys(balances).map((address) => {
+  const elements = Object.keys(balances).map(address => {
     const balance = toWei(balances[address]);
     return soliditySha3(address, balance) as string;
   });

--- a/client/src/helpers/utils.ts
+++ b/client/src/helpers/utils.ts
@@ -76,10 +76,9 @@ export function sleep(ms) {
 }
 
 export async function getSnapshot() {
-  const networkStr = config.chainId === 1 ? '' : '-kovan';
-
+  const url = "https://github.com/balancer-labs/bal-mining-scripts/blob/master/reports/_current.json"
   const claim = await fetch(
-    `https://storageapi.fleek.co/balancer-team-bucket/balancer-claim${networkStr}/snapshot`
+    config.snapshotUrl
   );
   const res = await claim.json();
 

--- a/client/src/i18n.ts
+++ b/client/src/i18n.ts
@@ -11,6 +11,11 @@ export default new VueI18n({
     en: {
       messages: {
         EMPTY_STATE: 'No results found'
+      },
+      rewardToken: {
+        pending: 'Pending {rewardToken}',
+        totalPending: 'Total pending {rewardToken}',
+        claimed: 'Claimed {rewardToken}'
       }
     }
   },

--- a/client/src/store/modules/app.ts
+++ b/client/src/store/modules/app.ts
@@ -91,7 +91,10 @@ const actions = {
       //console.log('Claim payload', claims);
       const tx = await dispatch('sendTransaction', params);
       const amountStr = numeral(totalClaim).format('(0.[00]a)');
-      dispatch('notify', ['green', `You've just claimed ${amountStr} BAL!`]);
+      dispatch('notify', [
+        'green',
+        `You've just claimed ${amountStr} ${config.rewardToken}!`
+      ]);
       commit('CLAIM_WEEKS_SUCCESS');
       return tx;
     } catch (e) {

--- a/client/src/store/modules/app.ts
+++ b/client/src/store/modules/app.ts
@@ -73,7 +73,7 @@ const actions = {
       const merkleTree = loadTree(state.reports[week]);
 
       // Get merkle root
-      console.log(week, merkleTree.getHexRoot());
+      //console.log(week, merkleTree.getHexRoot());
 
       const proof = merkleTree.getHexProof(
         soliditySha3(address, toWei(claimBalance))
@@ -88,7 +88,7 @@ const actions = {
         'claimWeeks',
         [address, claims]
       ];
-      console.log('Claim payload', claims);
+      //console.log('Claim payload', claims);
       const tx = await dispatch('sendTransaction', params);
       const amountStr = numeral(totalClaim).format('(0.[00]a)');
       dispatch('notify', ['green', `You've just claimed ${amountStr} BAL!`]);

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -2,7 +2,7 @@
   <div class="pt-2">
     <Container :slim="true">
       <Block class="text-center py-4">
-        <h1 class="mb-2">Claim BAL</h1>
+        <h1 class="mb-2">Claim {{ config.rewardToken }}</h1>
         <form
           @submit.prevent="handleSubmit"
           style="max-width: 460px;"
@@ -45,7 +45,7 @@
               <div class="flex-auto">
                 <User :address="address" />
               </div>
-              <div>{{ $n(dist) }} BAL</div>
+              <div>{{ $n(dist) }} {{ config.rewardToken }}</div>
             </div>
           </div>
         </Block>

--- a/client/src/views/User.vue
+++ b/client/src/views/User.vue
@@ -24,7 +24,12 @@
               <Icon name="external-link" class="ml-1" />
             </p>
           </a>
-          <Block :slim="true" title="Pending BAL">
+          <Block
+            :slim="true"
+            :title="
+              $t('rewardToken.pending', { rewardToken: config.rewardToken })
+            "
+          >
             <div class="overflow-hidden">
               <div
                 v-for="(dist, week, i) in unclaimed"
@@ -45,20 +50,22 @@
                     <Icon name="external-link" class="ml-1" />
                   </a>
                 </div>
-                <div>{{ $n(dist) }} BAL</div>
+                <div>{{ $n(dist) }} {{ config.rewardToken }}</div>
               </div>
               <p
                 v-if="Object.keys(unclaimed).length === 0"
                 class="p-4 m-0 d-block"
               >
-                There isn't any pending BAL here.
+                There isn't any pending {{ config.rewardToken }} here.
               </p>
             </div>
           </Block>
           <Block
             v-if="Object.keys(claimed).length > 0"
             :slim="true"
-            title="Claimed BAL"
+            :title="
+              $t('rewardToken.claimed', { rewardToken: config.rewardToken })
+            "
           >
             <div class="overflow-hidden">
               <div
@@ -80,16 +87,22 @@
                     <Icon name="external-link" class="ml-1" />
                   </a>
                 </div>
-                <div>{{ $n(dist) }} BAL</div>
+                <div>{{ $n(dist) }} {{ config.rewardToken }}</div>
               </div>
             </div>
           </Block>
         </div>
         <div class="col-12 col-lg-4 float-left">
-          <Block title="Total pending BAL">
+          <Block
+            :title="
+              $t('rewardToken.totalPending', {
+                rewardToken: config.rewardToken
+              })
+            "
+          >
             <div class="mb-2">
               <UiButton class="width-full mb-2">
-                {{ $n(totalUnclaimed) }} BAL
+                {{ $n(totalUnclaimed) }} {{ config.rewardToken }}
               </UiButton>
             </div>
             <UiButton

--- a/client/src/views/User.vue
+++ b/client/src/views/User.vue
@@ -40,7 +40,7 @@
                 <div class="flex-auto">
                   <a
                     :href="
-                      `https://github.com/balancer-labs/bal-mining-scripts/blob/master/reports/${_week(
+                      `${config.reportsUrl}/${_week(
                         week
                       )}/_totals.json`
                     "


### PR DESCRIPTION
Support LDO token claims by introducing via config for snapshots, token symbols etc

To finish this, we need to set up the required infrastructure for distributing the merkle trees, which is done in this PR https://github.com/balancer-labs/bal-mining-scripts/pull/111  Either can be merged first - this has no effect on the `claim.balancer.fi` interface

1. Snapshots of the claims available every week - a mapping between the week number and an ipfs file with all the distributions, like
`{"1": "Qm...<IPFSHASH>, "2": ...}
`these are currently uploaded to a fleek bucket, in BAL's case https://storageapi.fleek.co/balancer-team-bucket/balancer-claim/snapshot but will henceforth be loaded from githubusercontent directly

2. Links to the full json reports of who gets what ie
ie: https://github.com/balancer-labs/bal-mining-scripts/blob/master/reports/58/_totals.json
which are uploaded to ipfs and accessible via the link in the snapshot

Also
Made merkle helper typescript
comment out console logs