### PR TITLE
Only claim weeks in contract

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -4,6 +4,18 @@
     <div v-else>
       <Topnav />
       <div class="pb-6 overflow-hidden">
+        <Container :slim="true" v-if="app.migratedToOrchard">
+          <div class="d-flex flex-items-center text-white bg-blue" style="height: 100px;">
+            <div class="alert alert-primary p-5" role="alert">
+              <h2> Liquidity Mining Update</h2>
+              This distribution contract has been deprecated. Previous distributions will be claimable here forever. You might have additional distributions available to claim on the&nbsp;
+              <a href="https://app.balancer.fi" target="_blank">
+                main app
+                <Icon name="external-link" class="ml-1" />
+              </a>
+              </div>
+          </div>
+        </Container>
         <router-view :key="$route.path" class="flex-auto" />
       </div>
     </div>

--- a/client/src/config/homestead.json
+++ b/client/src/config/homestead.json
@@ -42,5 +42,6 @@
     }
   },
   "offset": 20,
+  "latestWeek": 51,
   "reportFilename": "_totals.json"
 }

--- a/client/src/store/modules/app.ts
+++ b/client/src/store/modules/app.ts
@@ -14,6 +14,7 @@ const state = {
   reports: {},
   firstWeek: 1,
   latestWeek: 0,
+  migratedToOrchard: false,
   latestReport: {}
 };
 
@@ -57,11 +58,16 @@ const actions = {
     const snapshot = await getSnapshot();
     let latestWeek = 0;
     let latestReport = {};
+    let migratedToOrchard = false
     const reports: Record<number, Report> = {};
+    const latestWeekInSnapshot = Math.max(...Object.keys(snapshot).map(numStr => parseInt(numStr)))
     if (Object.keys(snapshot).length > 0) {
-      latestWeek = typeof config.latestWeek != 'undefined' ?
+      const hasConfig = typeof config.latestWeek != 'undefined';
+      latestWeek = hasConfig ?
         config.latestWeek :
-        Math.max(...Object.keys(snapshot).map(numStr => parseInt(numStr)));
+        latestWeekInSnapshot;
+
+      migratedToOrchard = hasConfig && latestWeekInSnapshot > config.latestWeek;
 
       const latestWeekIpfsHash = snapshot[latestWeek.toString()];
       latestReport = await ipfs.get(latestWeekIpfsHash);
@@ -73,6 +79,7 @@ const actions = {
       snapshot,
       latestWeek,
       latestReport,
+      migratedToOrchard,
       reports
     });
   },

--- a/client/src/store/modules/web3.ts
+++ b/client/src/store/modules/web3.ts
@@ -172,11 +172,11 @@ const actions = {
             await dispatch('loadWeb3');
           }
         });
-        provider.on('close', async () => {
+        provider.on('disconnect', async () => {
           commit('HANDLE_CLOSE');
           await dispatch('logout');
         });
-        provider.on('networkChanged', async () => {
+        provider.on('chainChanged', async () => {
           commit('HANDLE_NETWORK_CHANGED');
           await dispatch('logout');
           await dispatch('login');


### PR DESCRIPTION
Since we're sharing manifests in bal-mining-scripts agnostic of the merkleRedeem -> merkleOrchard migration, we need to configure where the legacy claim interface should stop reporting weeks